### PR TITLE
Lua submodule, clone instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,13 @@ This is browser version of [Path of Building](https://pathofbuilding.community/)
 - [CMake](https://cmake.org/)
 - [Ninja](https://ninja-build.org/)
 
-### Clone the repository
+### Clone the Repository
 
-This repository include a [submodule](https://gist.github.com/gitaarik/8735255) in `vendor/lua`. To include the submodule when cloning the repository use the flag `--recurse-submodules`:
+This repository includes a [submodule](https://gist.github.com/gitaarik/8735255) in `vendor/lua`. To include the submodule when cloning the repository, use the `--recurse-submodules` flag:
 ```bash
-git clone --recurse-submodules
+git clone --recurse-submodules <repository-url>
 ```
-If you ommitted the flag, you can use the following commands to clone the submodule:
+If you omitted the flag, you can use the following commands to clone the submodule:
 ```bash
 git submodule init
 git submodule update

--- a/README.md
+++ b/README.md
@@ -33,6 +33,18 @@ This is browser version of [Path of Building](https://pathofbuilding.community/)
 - [CMake](https://cmake.org/)
 - [Ninja](https://ninja-build.org/)
 
+### Clone the repository
+
+This repository include a [submodule](https://gist.github.com/gitaarik/8735255) in `vendor/lua`. To include the submodule when cloning the repository use the flag `--recurse-submodules`:
+```bash
+git clone --recurse-submodules
+```
+If you ommitted the flag, you can use the following commands to clone the submodule:
+```bash
+git submodule init
+git submodule update
+```
+
 ### Install dependencies
 
 ```bash


### PR DESCRIPTION
Hello,

When attempting to build the driver I got in trouble with a "lua.h is missing" error.
It took me a few minutes to realize the repo included a submodule for Lua.
The section I added to the README can save others some trouble.

Gj for your work, and thank you for making it open-source :-)