### PR TITLE
fix(driver): add double-click support to keyboard event handling

### DIFF
--- a/packages/driver/src/js/driver.ts
+++ b/packages/driver/src/js/driver.ts
@@ -144,9 +144,10 @@ export class Driver {
     this.adjustCanvasForOverlay();
 
     this.pobKeyboardState = PoBKeyboardState.make({
-      onKeyDown: (state: PoBKeyboardState, key: PoBKey) => {
+      onKeyDown: (state: PoBKeyboardState, key: PoBKey, doubleClick: number) => {
         this.driverWorker?.updateKeyboardState(state.pobKeys);
-        this.driverWorker?.handleKeyDown(key, 0);
+        this.driverWorker?.handleKeyDown(key, doubleClick);
+        if (doubleClick > 0) this.driverWorker?.handleKeyUp(key, 0);
       },
       onKeyUp: (state: PoBKeyboardState, key: PoBKey) => {
         this.driverWorker?.updateKeyboardState(state.pobKeys);

--- a/packages/driver/src/js/keyboard.ts
+++ b/packages/driver/src/js/keyboard.ts
@@ -7,7 +7,7 @@ declare const PoBKeySymbol: unique symbol;
 export type PoBKey = string & { [PoBKeySymbol]: never };
 
 export type KeyboardStateCallbacks = {
-  onKeyDown: (state: PoBKeyboardState, key: PoBKey) => void;
+  onKeyDown: (state: PoBKeyboardState, key: PoBKey, doubleClick: number) => void;
   onKeyUp: (state: PoBKeyboardState, key: PoBKey) => void;
   onChar: (state: PoBKeyboardState, char: string) => void;
 };
@@ -27,9 +27,11 @@ export const PoBKeyboardState = {
     return {
       pobKeys: keys,
 
-      keydown(pobKey: PoBKey): void {
-        keys.add(pobKey);
-        callbacks?.onKeyDown(this, pobKey);
+      keydown(pobKey: PoBKey, doubleclick: number): void {
+        if (doubleclick < 1) {
+          keys.add(pobKey);
+        }
+        callbacks?.onKeyDown(this, pobKey, doubleclick);
       },
 
       keyup(pobKey: PoBKey): void {


### PR DESCRIPTION
This pull request updates the keyboard handling logic to support double-click detection and propagation through the keyboard state system. The main changes involve updating callback signatures and logic to handle a `doubleClick` parameter, and ensuring that double-click events trigger the appropriate key up and down actions.

Keyboard handling improvements:

* Updated the `onKeyDown` callback in `KeyboardStateCallbacks` to include a `doubleClick` parameter, allowing the system to differentiate between single and double key presses.
* Modified the `keydown` method in `PoBKeyboardState` to accept a `doubleclick` argument, only adding the key to the set if it is not a double-click, and always calling the updated `onKeyDown` callback.
* Updated the `Driver` class to pass the `doubleClick` parameter through to `handleKeyDown`, and to trigger a corresponding `handleKeyUp` when a double-click is detected.