### PR TITLE
fix(driver): add support for new lcurl options for SSL and redirects

### DIFF
--- a/packages/driver/src/c/lcurl.c
+++ b/packages/driver/src/c/lcurl.c
@@ -150,7 +150,7 @@ static int lcurl_easy_setopt(lua_State *L) {
             // no-op
             break;
         }
-        OPT_SSL_VERIFYHOST: {
+        case OPT_SSL_VERIFYHOST: {
             // no-op
             break;
         }


### PR DESCRIPTION
This pull request adds support for several new option constants related to HTTP redirects and SSL verification in the `lcurl` Lua C module, though these options are currently implemented as no-ops. The changes ensure these options can be set without causing errors, improving compatibility with code that expects them.

New option constants and handling:

* Added new option constants: `OPT_FOLLOWLOCATION`, `OPT_SSL_VERIFYPEER`, and `OPT_SSL_VERIFYHOST` to the enum in `lcurl.c` for following HTTP redirects and SSL verification settings.
* Registered the new option constants with the Lua module so they are accessible from Lua code.
* Updated the `lcurl_easy_setopt` function to handle the new options as no-ops, allowing them to be set without effect or error.Added placeholder implementations for new LuaJIT options: `OPT_FOLLOWLOCATION`, `OPT_SSL_VERIFYPEER`, and `OPT_SSL_VERIFYHOST`. The options are defined, exposed in the Lua interface, and handled as no-operations for now.