### PR TITLE
feat(driver): add getBuildCode() to extract current build as shareable code

### DIFF
--- a/packages/driver/boot.lua
+++ b/packages/driver/boot.lua
@@ -190,3 +190,21 @@ function loadBuildFromCode(code)
     -- Flush to process the import
     runCallback("OnFrame")
 end
+
+function getBuildCode()
+    if not mainObject.main then
+        error("getBuildCode: mainObject.main is nil")
+    end
+
+    local build = mainObject.main.modes["BUILD"]
+    if not build then
+        error("getBuildCode: not in BUILD mode")
+    end
+
+    local xmlText = build:SaveDB("code")
+    if not xmlText then
+        error("getBuildCode: SaveDB returned nil")
+    end
+
+    return common.base64.encode(Deflate(xmlText)):gsub("+","-"):gsub("/","_")
+end

--- a/packages/driver/src/c/driver.c
+++ b/packages/driver/src/c/driver.c
@@ -558,3 +558,27 @@ int load_build_from_code(const char *code) {
     }
     return 0;
 }
+
+static char *s_build_code = NULL;
+
+EMSCRIPTEN_KEEPALIVE
+const char* get_build_code() {
+    lua_State *L = GL;
+
+    free(s_build_code);
+    s_build_code = NULL;
+
+    lua_getglobal(L, "getBuildCode");
+    if (lua_pcall(L, 0, 1, 0) != LUA_OK) {
+        fprintf(stderr, "Error: %s\n", lua_tostring(L, -1));
+        lua_pop(L, 1);
+        return NULL;
+    }
+
+    size_t len;
+    const char *code = lua_tolstring(L, -1, &len);
+    s_build_code = malloc(len + 1);
+    memcpy(s_build_code, code, len + 1);
+    lua_pop(L, 1);
+    return s_build_code;
+}

--- a/packages/driver/src/js/driver.ts
+++ b/packages/driver/src/js/driver.ts
@@ -281,6 +281,14 @@ export class Driver {
     return this.driverWorker?.loadBuildFromCode(code);
   }
 
+  async getBuildCode(): Promise<string> {
+    const code = await this.driverWorker?.getBuildCode();
+    if (!code) {
+      throw new Error("getBuildCode failed");
+    }
+    return code;
+  }
+
   setLayerVisible(layer: number, sublayer: number, visible: boolean) {
     return this.driverWorker?.setLayerVisible(layer, sublayer, visible);
   }

--- a/packages/driver/src/js/worker.ts
+++ b/packages/driver/src/js/worker.ts
@@ -103,6 +103,7 @@ type Imports = {
   init: () => void;
   start: () => void;
   loadBuildFromCode: (code: string) => number;
+  getBuildCode: () => string;
   onFrame: () => void;
   onKeyUp: (name: string, doubleClick: number) => void;
   onKeyDown: (name: string, doubleClick: number) => void;
@@ -308,6 +309,14 @@ export class DriverWorker {
     this.invalidate();
   }
 
+  async getBuildCode(): Promise<string> {
+    const code = await this.imports?.getBuildCode();
+    if (!code) {
+      throw new Error("getBuildCode failed");
+    }
+    return code;
+  }
+
   setLayerVisible(layer: number, sublayer: number, visible: boolean) {
     this.renderer?.setLayerVisible(layer, sublayer, visible);
     this.invalidate();
@@ -343,6 +352,7 @@ export class DriverWorker {
       init: module.cwrap("init", "number", [], { async: true }),
       start: module.cwrap("start", "number", [], { async: true }),
       loadBuildFromCode: module.cwrap("load_build_from_code", "number", ["string"], { async: true }),
+      getBuildCode: module.cwrap("get_build_code", "string", [], { async: true }),
       onFrame: module.cwrap("on_frame", "number", [], { async: true }),
       onKeyUp: module.cwrap("on_key_up", "number", ["string", "number"]),
       onKeyDown: module.cwrap("on_key_down", "number", ["string", "number"]),


### PR DESCRIPTION
## Summary

Adds `getBuildCode()` as the symmetric counterpart to the existing `loadBuildFromCode()`. Serializes the current build back to the standard PoB share-code format — `base64url(zlib(xml))` — so embedders can round-trip: load a code → user/agent edits → read the code back out.

The shape mirrors `loadBuildFromCode` exactly; changes are threaded through all four layers:

| Layer | Addition |
|---|---|
| `packages/driver/boot.lua` | `getBuildCode()` Lua function — calls `build:SaveDB("code")`, deflates, URL-safe base64 |
| `packages/driver/src/c/driver.c` | `get_build_code()` exported C function with static buffer lifecycle matching the existing `s_*` pattern |
| `packages/driver/src/js/worker.ts` | `getBuildCode()` on `DriverWorker` + `cwrap` binding |
| `packages/driver/src/js/driver.ts` | `getBuildCode(): Promise<string>` public API on `Driver` |

## Motivation

I'm embedding pob-web in a build-analysis app where an AI agent mutates the build XML. After mutation, I need to serialize the current in-memory build back to a code to persist/share it. Today `loadBuildFromCode` gets you *in* to pob-web; there's no symmetric way to get *out*. This closes that gap with a minimally-invasive addition.

## Design notes

- **No new dependencies** — reuses `common.base64` and `Deflate` already in PoB, same as `loadBuildFromCode`.
- **Error surface matches existing code** — Lua-side `error()` on missing `mainObject.main` / wrong mode, C-side prints to `stderr` and returns `NULL` on pcall failure, matches the style of `load_build_from_code` in the same file.
- **Static buffer `s_build_code`** follows the existing pattern in `driver.c`; freed on next call.
- **URL-safe base64** (`+`→`-`, `/`→`_`) matches what `loadBuildFromCode` accepts, so the output is a drop-in input for the inverse call.

## Test plan

- [ ] Manual round-trip: `await driver.loadBuildFromCode(code); const out = await driver.getBuildCode();` and confirm the resulting XML (after base64/inflate) equals the input XML for at least one non-trivial build
- [ ] Error path: call `getBuildCode()` before a build is loaded — expect a rejected promise with a clear error
- [ ] Verify `dist/driver.wasm` size doesn't meaningfully regress

Happy to adjust naming, error handling, or scope if you'd prefer a different shape.